### PR TITLE
[add]分類情報画面への遷移 MVC①

### DIFF
--- a/DroneInventorySystem/.gitignore
+++ b/DroneInventorySystem/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/bin/

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -25,6 +25,9 @@ public class UrlConsts {
 
 	// 在庫センター情報画面 検索
 	public static final String CENTER_INFO_SEARCH = "/admin/centerInfo/search";
+	
+	// 分類情報画面
+	public static final String CATEGORY_INFO = "/admin/categoryInfo";
 
 	// 認証不要画面
 	public static final String[] NO_AUTHENTICATION = {LOGIN, AUTHENTICATE};

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoController.java
@@ -1,0 +1,31 @@
+package com.digitalojt.web.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.digitalojt.web.consts.UrlConsts;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+* 在庫センター情報画面のコントローラークラス
+* 
+* @author yamato mizoguchi
+*
+*/
+@Controller
+@RequiredArgsConstructor
+public class CategoryInfoController {
+	
+	/**
+	 * 初期表示
+	 * 
+	 * @param model
+	 * @return
+	 */
+	@GetMapping(UrlConsts.CATEGORY_INFO)
+	public String index(Model model) {
+		return "admin/categoryInfo/index";
+	}
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfo/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
+ >
+  <head>
+    <title>InvenTrack</title>
+  </head>
+  <body>
+	<div class="card shadow mb-4">
+		<div class="card-header py-3">
+					<h6 class="m-0 font-weight-bold text-primary">Hello world</h6>
+		</div>
+		<div class="card-body">
+		</div>
+	</div>
+  </body>
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
@@ -26,7 +26,7 @@
 				<a class="nav-link" th:href="@{'/admin/stockList'}">
 					<span>在庫一覧</span>
 				</a>
-				<a class="nav-link" th:href="@{'/admin/stockList'}">
+				<a class="nav-link" th:href="@{'/admin/categoryInfo'}">
 					<span>分類情報管理</span>
 				</a>
 				<a class="nav-link" th:href="@{'/admin/centerInfo'}">


### PR DESCRIPTION
## 概要

MVC①
分類情報画面を作成し遷移できるようにしました。
ご確認よろしくお願いいたします。

## 変更箇所

・UrlConstsに分類情報画面のパスを追加。
・controllerにCategoryInfoControllerを追加
・分類情報画面のindex.htmlを作成
